### PR TITLE
Replaced hard coded "eosio" with get_self() when require_auth()'d

### DIFF
--- a/eosio.assert/src/eosio.assert.cpp
+++ b/eosio.assert/src/eosio.assert.cpp
@@ -23,7 +23,7 @@ struct[[eosio::contract("eosio.assert")]] asserter : eosio::contract {
    stored_chain_params chain = chain_table.get_or_default();
 
    [[eosio::action]] void setchain(ignore<checksum256> chain_id, ignore<string> chain_name, ignore<checksum256> icon) {
-      require_auth("eosio"_n);
+      require_auth(get_self());
       auto hash = eosio::sha256(_ds.pos(), _ds.remaining());
       _ds >> chain.chain_id;
       _ds >> chain.chain_name;


### PR DESCRIPTION


<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
The code should not make assumptions about the permission structure of the chain.
In some cases it might be even preferred that setchain() would be called by some sort
of referendum mechanism.

Usually maintenance and setup is handled by the get_self()@active, now this contract
follows that convention.

## API Changes
- [ ] API Changes

## Documentation Additions
- [ ] Documentation Additions
No changes: most chains have eosio@active as eosio.assert@active anyway.
